### PR TITLE
upstream fixes - no more infra/global errors

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -15,55 +15,9 @@ data "aws_iam_policy_document" "assume_role" {
   }
 }
 
-data "aws_iam_policy_document" "lambda_basic" {
-  count = (var.create == true ? 1 : 0)
-
-  statement {
-    sid = "AllowWriteToCloudwatchLogs"
-
-    effect = "Allow"
-
-    actions = [
-      "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-    ]
-
-    resources = [
-      "arn:aws:logs:*:*:*"]
-  }
-}
-
-data "aws_iam_policy_document" "lambda" {
-  count = var.create_with_kms_key == 1 ? 1 : 0 * (var.create == true ? 1 : 0)
-
-  source_json = data.aws_iam_policy_document.lambda_basic[0].json
-
-  statement {
-    sid = "AllowKMSDecrypt"
-
-    effect = "Allow"
-
-    actions = [
-      "kms:Decrypt"]
-
-    resources = [
-      var.kms_key_arn == "" ? "" : var.kms_key_arn]
-  }
-}
-
 resource "aws_iam_role" "lambda" {
   count = (var.create == true ? 1 : 0)
 
   name_prefix = "lambda"
   assume_role_policy = data.aws_iam_policy_document.assume_role[0].json
-}
-
-resource "aws_iam_role_policy" "lambda" {
-  count = (var.create == true ? 1 : 0)
-
-  name_prefix = "lambda-policy-"
-  role = aws_iam_role.lambda[0].id
-
-  policy = element(compact(concat(data.aws_iam_policy_document.lambda.*.json, data.aws_iam_policy_document.lambda_basic.*.json)), 0)
 }

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,12 @@ data "aws_sns_topic" "this" {
   name = var.sns_topic_name
 }
 
+resource "aws_cloudwatch_log_group" "lambda" {
+  count = (var.create == true ? 1 : 0)
+  name = "/aws/lambda/${var.lambda_function_name}"
+  retention_in_days = 30
+}
+
 resource "aws_sns_topic" "this" {
   count = (var.create_sns_topic == true ? 1 : 0) * (var.create == true ? 1 : 0)
 
@@ -13,80 +19,114 @@ resource "aws_sns_topic" "this" {
 locals {
   sns_topic_arn = element(concat(aws_sns_topic.this.*.arn, data.aws_sns_topic.this.*.arn, [
     ""]), 0)
+
+  lambda_policy_document = {
+    sid       = "AllowWriteToCloudwatchLogs"
+    effect    = "Allow"
+    actions   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = [replace("${element(concat(aws_cloudwatch_log_group.lambda[*].arn, list("")), 0)}:*", ":*:*", ":*")]
+  }
+
+  lambda_policy_document_kms = {
+    sid       = "AllowKMSDecrypt"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = [var.kms_key_arn]
+  }
+}
+
+data "aws_iam_policy_document" "lambda" {
+  count = var.create ? 1 : 0
+
+  dynamic "statement" {
+    for_each = concat([local.lambda_policy_document], var.kms_key_arn != "" ? [local.lambda_policy_document_kms] : [])
+    content {
+      sid       = statement.value.sid
+      effect    = statement.value.effect
+      actions   = statement.value.actions
+      resources = statement.value.resources
+    }
+  }
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack" {
   count = (var.create == true ? 1 : 0)
 
-  topic_arn = local.sns_topic_arn
-  protocol = "lambda"
-  endpoint = aws_lambda_function.notify_slack[0].arn
-}
-
-resource "aws_lambda_permission" "sns_notify_slack" {
-  count = (var.create == true ? 1 : 0)
-
-  statement_id = "AllowExecutionFromSNS"
-  action = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.notify_slack[0].function_name
-  principal = "sns.amazonaws.com"
-  source_arn = local.sns_topic_arn
-}
-
-data "null_data_source" "lambda_file" {
-  inputs = {
-    filename = "${path.module}/functions/notify_slack.py"
-  }
-}
-
-data "null_data_source" "lambda_archive" {
-  inputs = {
-    filename = "${path.module}/functions/notify_slack.zip"
-  }
+  topic_arn     = local.sns_topic_arn
+  protocol      = "lambda"
+  endpoint      = module.lambda.this_lambda_function_arn
+  filter_policy = var.subscription_filter_policy
 }
 
 data "archive_file" "notify_slack" {
   count = (var.create == true ? 1 : 0)
 
   type = "zip"
-  source_file = data.null_data_source.lambda_file.outputs.filename
-  output_path = data.null_data_source.lambda_archive.outputs.filename
+  output_path = "${path.module}/files/dotfiles.zip"
+  source {
+    content = file("${path.module}/functions/notify_slack.py")
+    filename = "notify_slack.py"
+  }
 }
 
-resource "aws_lambda_function" "notify_slack" {
-  count = (var.create == true ? 1 : 0)
+module "lambda" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "1.28.0"
 
-  filename = data.archive_file.notify_slack[0].output_path
+  create = var.create
 
   function_name = var.lambda_function_name
+  description   = var.lambda_description
 
-  role = aws_iam_role.lambda[0].arn
-  handler = "notify_slack.lambda_handler"
-  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
-  runtime = "python3.7"
-  timeout = 30
-  kms_key_arn = var.kms_key_arn
+  handler                        = "notify_slack.lambda_handler"
+  source_path                    = "${path.module}/functions/notify_slack.py"
+  runtime                        = "python3.8"
+  timeout                        = 30
+  kms_key_arn                    = var.kms_key_arn
+  reserved_concurrent_executions = var.reserved_concurrent_executions
 
-  environment {
-    variables = {
-      SLACK_WEBHOOK_URL = var.slack_webhook_url
-      SLACK_CHANNEL = var.slack_channel
-      SLACK_USERNAME = var.slack_username
-      SLACK_EMOJI = var.slack_emoji
-      ENVIRONMENT = var.environment
+  # If publish is disabled, there will be "Error adding new Lambda Permission for notify_slack: InvalidParameterValueException: We currently do not support adding policies for $LATEST."
+  publish = true
+
+  environment_variables = {
+    SLACK_WEBHOOK_URL = var.slack_webhook_url
+    SLACK_CHANNEL     = var.slack_channel
+    SLACK_USERNAME    = var.slack_username
+    SLACK_EMOJI       = var.slack_emoji
+    LOG_EVENTS        = var.log_events ? "True" : "False"
+    ENVIRONMENT       = var.environment
+  }
+
+  lambda_role               = aws_iam_role.lambda[0].arn
+  role_name                 = "${var.iam_role_name_prefix}-${var.lambda_function_name}"
+  role_permissions_boundary = var.iam_role_boundary_policy_arn
+  role_tags                 = var.iam_role_tags
+
+  # Do not use Lambda's policy for cloudwatch logs, because we have to add a policy
+  # for KMS conditionally. This way attach_policy_json is always true independenty of
+  # the value of presense of KMS's famous "computed values in count" bug...
+  attach_cloudwatch_logs_policy = false
+  attach_policy_json            = true
+  policy_json                   = element(concat(data.aws_iam_policy_document.lambda[*].json, [""]), 0)
+
+  use_existing_cloudwatch_log_group = true
+  attach_network_policy             = var.lambda_function_vpc_subnet_ids != null
+
+  allowed_triggers = {
+    AllowExecutionFromSNS = {
+      principal  = "sns.amazonaws.com"
+      source_arn = local.sns_topic_arn
     }
   }
 
-  lifecycle {
-    ignore_changes = [
-      filename,
-      last_modified,
-    ]
-  }
+  store_on_s3 = var.lambda_function_store_on_s3
+  s3_bucket   = var.lambda_function_s3_bucket
+
+  vpc_subnet_ids         = var.lambda_function_vpc_subnet_ids
+  vpc_security_group_ids = var.lambda_function_vpc_security_group_ids
+
+  tags = merge(var.tags, var.lambda_function_tags)
+
+  depends_on = [aws_cloudwatch_log_group.lambda]
 }
 
-resource "aws_cloudwatch_log_group" "lambda_logs" {
-  count = (var.create == true ? 1 : 0)
-  name = "/aws/lambda/${var.lambda_function_name}"
-  retention_in_days = 30
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,55 +1,44 @@
 output "this_slack_topic_arn" {
   description = "The ARN of the SNS topic from which messages will be sent to Slack"
-  value = local.sns_topic_arn
+  value       = local.sns_topic_arn
 }
 
 output "lambda_iam_role_arn" {
   description = "The ARN of the IAM role used by Lambda function"
-  value = element(concat(aws_iam_role.lambda.*.arn, [
-    ""]), 0)
+  value       = module.lambda.lambda_role_arn
 }
 
 output "lambda_iam_role_name" {
   description = "The name of the IAM role used by Lambda function"
-  value = element(concat(aws_iam_role.lambda.*.arn, [
-    ""]), 0)
+  value       = module.lambda.lambda_role_name
 }
 
 output "notify_slack_lambda_function_arn" {
   description = "The ARN of the Lambda function"
-  value = element(concat(aws_lambda_function.notify_slack.*.arn, [
-    ""]), 0)
+  value       = module.lambda.this_lambda_function_arn
 }
 
 output "notify_slack_lambda_function_name" {
   description = "The name of the Lambda function"
-  value = element(
-  concat(aws_lambda_function.notify_slack.*.function_name, [
-    ""]),
-  0,
-  )
+  value       = module.lambda.this_lambda_function_name
 }
 
 output "notify_slack_lambda_function_invoke_arn" {
   description = "The ARN to be used for invoking Lambda function from API Gateway"
-  value = element(
-  concat(aws_lambda_function.notify_slack.*.invoke_arn, [
-    ""]),
-  0,
-  )
+  value       = module.lambda.this_lambda_function_invoke_arn
 }
 
 output "notify_slack_lambda_function_last_modified" {
   description = "The date Lambda function was last modified"
-  value = element(
-  concat(aws_lambda_function.notify_slack.*.last_modified, [
-    ""]),
-  0,
-  )
+  value       = module.lambda.this_lambda_function_last_modified
 }
 
 output "notify_slack_lambda_function_version" {
   description = "Latest published version of your Lambda function"
-  value = element(concat(aws_lambda_function.notify_slack.*.version, [
-    ""]), 0)
+  value       = module.lambda.this_lambda_function_version
+}
+
+output "lambda_cloudwatch_log_group_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the log group"
+  value       = element(concat(aws_cloudwatch_log_group.lambda.*.arn, [""]), 0)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,21 +1,85 @@
 variable "create" {
   description = "Whether to create all resources"
-  default = true
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
 }
 
 variable "create_sns_topic" {
   description = "Whether to create new SNS topic"
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "create_with_kms_key" {
   description = "Whether to create resources with KMS encryption"
-  default = false
+  type        = bool
+  default     = false
+}
+
+variable "reserved_concurrent_executions" {
+  description = "The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations"
+  type        = number
+  default     = -1
+}
+
+variable "subscription_filter_policy" {
+  description = "(Optional) A valid filter policy that will be used in the subscription to filter messages seen by the target resource."
+  type        = string
+  default     = null
+}
+
+variable "iam_role_name_prefix" {
+  description = "A unique role name beginning with the specified prefix"
+  type        = string
+  default     = "lambda"
 }
 
 variable "lambda_function_name" {
   description = "The name of the Lambda function to create"
-  default = "notify_slack"
+  type        = string
+  default     = "notify_slack"
+}
+
+variable "lambda_description" {
+  description = "The description of the Lambda function"
+  type        = string
+  default     = null
+}
+
+variable "lambda_function_tags" {
+  description = "Additional tags for the Lambda function"
+  type        = map(string)
+  default     = {}
+}
+
+variable "lambda_function_store_on_s3" {
+  description = "Whether to store produced artifacts on S3 or locally."
+  type        = bool
+  default     = false
+}
+
+variable "lambda_function_s3_bucket" {
+  description = "S3 bucket to store artifacts"
+  type        = string
+  default     = null
+}
+
+variable "lambda_function_vpc_subnet_ids" {
+  description = "List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets."
+  type        = list(string)
+  default     = null
+}
+
+variable "lambda_function_vpc_security_group_ids" {
+  description = "List of security group ids when Lambda Function should run in the VPC."
+  type        = list(string)
+  default     = null
 }
 
 variable "sns_topic_name" {
@@ -36,15 +100,33 @@ variable "slack_username" {
 
 variable "slack_emoji" {
   description = "A custom emoji that will appear on Slack messages"
-  default = ":aws:"
+  default     = ":aws:"
 }
 
 variable "kms_key_arn" {
   description = "ARN of the KMS key used for decrypting slack webhook url"
-  default = ""
+  default     = ""
 }
 
 variable "environment" {
   description = "Environment of the notification"
-  default = "none"
+  default     = "none"
+}
+
+variable "iam_role_tags" {
+  description = "Additional tags for the IAM role"
+  type        = map(string)
+  default     = {}
+}
+
+variable "iam_role_boundary_policy_arn" {
+  description = "The ARN of the policy that is used to set the permissions boundary for the role"
+  type        = string
+  default     = null
+}
+
+variable "log_events" {
+  description = "Boolean flag to enabled/disable logging of incoming events"
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
## Description

Fixes AP-3565. Needed by AP-5712.
- biggest fix is moving to using Lambda module instead of self-declaring Lambda resources (fixes the zipfile hash errors)
- IAM resources now defined via looping over local variables
- added variables/outputs to support new module use
- tested against infra/global/regions/ids/ec2-alarms.tf (termination notifications) in staging

## Risk Assessment
*What are the risks? Is there a business impact?*

No known risks or business impact.

## Performance Impact
*Please describe any relevant performance impact of this change. This can be positive or negative impact. How did you characterize/test the performance impact?*

No known or significant performance impact. 

## Testing Assessment
*Please describe what testing has been done.*

- [x] Unit Tests
- [x] Integration Tests

## Security Assessment
*Please verify that the change does not introduce any of the following security issues.*

- [x] Injection Flaws
- [x] Buffer overflows
- [x] Insecure Cryptographic Storage
- [x] Insecure Communications
- [x] Improper Error Handling
- [x] XSS
- [x] Improper Access Control
- [x] CSRF
